### PR TITLE
Prevent directions from stacking up

### DIFF
--- a/public_html/js/5nake.1.1.203.js
+++ b/public_html/js/5nake.1.1.203.js
@@ -356,7 +356,9 @@ $(document).ready(function(){
 		
 		if(next_direction){ // Don't add to array if the user isn't sending a direction
 		    e.preventDefault(); // Prevent the user from scrolling the page
-			keystroke_array.push(next_direction);
+                        if (keystroke_array[keystroke_array.length - 1] !== next_direction) { // prevent the same direction to stack up
+                            keystroke_array.push(next_direction);
+                        }
 		}
 	});	
 	


### PR DESCRIPTION
I've played around with the snake a bit and found a tiny bug. IF a user keep holding down a key, the direction commands will stack up and the next direction will be executed after all are released which produces lag.
